### PR TITLE
CF: try API to get status when the original way fails

### DIFF
--- a/vjudge-v2/CFJudger.cpp
+++ b/vjudge-v2/CFJudger.cpp
@@ -230,15 +230,9 @@ Bott * CFJudger::getStatus(Bott * bott) {
                 performCurl();
 
                 string json = loadAllFromFile(tmpfilename);
-                
-                Json::Reader json_reader;
-                Json::Value api_ret;
-                if (json_reader.parse(json, api_ret)) {
-                    runid = intToString(api_ret["result"][0]["id"].asInt());
-                    result = api_ret["result"][0]["verdict"].asString();
-                    time_used = intToString(api_ret["result"][0]["timeConsumedMillis"].asInt());
-                    memory_used = intToString(api_ret["result"][0]["memeryConsumedBytes"].asInt() / 1024);
-                }else{
+                if (!RE2::PartialMatch(json,
+                                      "(?s)\"id\":([0-9]*)\"verdict\":\"(.*?)\".*\"timeConsumedMillis\":([0-9]*),\"memeryConsumedBytes\":([0-9]*)",
+                                      &runid, &result, &time_used, &memory_used)) {
                     throw Exception("Failed to parse details from API.");
                 }
             }

--- a/vjudge-v2/vjudge.h
+++ b/vjudge-v2/vjudge.h
@@ -37,6 +37,7 @@
 #include "curl/curl.h"
 #include "re2/re2.h"
 #include "htmlcxx/html/ParserDom.h"
+#include "jsoncpp/json/json.h"
 
 #include "hcxselect.h"
 

--- a/vjudge-v2/vjudge.h
+++ b/vjudge-v2/vjudge.h
@@ -37,7 +37,6 @@
 #include "curl/curl.h"
 #include "re2/re2.h"
 #include "htmlcxx/html/ParserDom.h"
-#include "jsoncpp/json/json.h"
 
 #include "hcxselect.h"
 


### PR DESCRIPTION
Since CF's API won't result judging submissions, the original way can't be replaced totally by the use of API, but this will provide a workround when it fails....

Please note that this adds jsoncpp library to dependency.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bnuacm/bnuoj-vjudge/3)

<!-- Reviewable:end -->
