### PR TITLE
Cleanup legacy type confusions in Bott.cpp

### DIFF
--- a/vjudge-v2/ACdreamJudger.cpp
+++ b/vjudge-v2/ACdreamJudger.cpp
@@ -8,8 +8,8 @@
 #include "ACdreamJudger.h"
 
 ACdreamJudger::ACdreamJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "2";
-  language_table["2"]  = "1";
+  language_table[CPPLANG]  = "2";
+  language_table[CLANG]  = "1";
 }
 
 ACdreamJudger::~ACdreamJudger() {
@@ -44,8 +44,9 @@ void ACdreamJudger::login() {
 int ACdreamJudger::submit(Bott * bott) {
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL, "http://acdream.info/submit");
-  string post = (string) "pid=" + bott->Getvid() + "&lang=" +
-      escapeURL(bott->Getlanguage()) + "&code=" + escapeURL(bott->Getsrc());
+  string post = (string) "pid=" + bott->Getvid() +
+      "&lang=" + convertLanguage(bott->Getlanguage()) +
+      "&code=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
 
   try {
@@ -79,7 +80,7 @@ Bott * ACdreamJudger::getStatus(Bott * bott) {
         curl, CURLOPT_URL,
         ((string) "http://acdream.info/status?name=" +
             escapeURL(info->GetUsername()) + "&pid=" + bott->Getvid() +
-            "&lang=" + bott->Getlanguage()).c_str());
+            "&lang=" + convertLanguage(bott->Getlanguage())).c_str());
     performCurl();
 
     string html = loadAllFromFile(tmpfilename);
@@ -106,8 +107,8 @@ Bott * ACdreamJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/AizuJudger.cpp
+++ b/vjudge-v2/AizuJudger.cpp
@@ -8,12 +8,12 @@
 #include "AizuJudger.h"
 
 AizuJudger::AizuJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "C++";
-  language_table["2"]  = "C";
-  language_table["3"]  = "JAVA";
-  language_table["6"]  = "C#";
-  language_table["5"]  = "Python";
-  language_table["9"]  = "Ruby";
+  language_table[CPPLANG]  = "C++";
+  language_table[CLANG]  = "C";
+  language_table[JAVALANG]  = "JAVA";
+  language_table[CSLANG]  = "C#";
+  language_table[PYLANG]  = "Python";
+  language_table[RUBYLANG]  = "Ruby";
 }
 
 AizuJudger::~AizuJudger() {
@@ -53,7 +53,7 @@ int AizuJudger::submit(Bott * bott) {
                    "http://judge.u-aizu.ac.jp/onlinejudge/servlet/Submit");
   string post = (string) "userID=" + escapeURL(info->GetUsername()) +
       "&password=" + escapeURL(info->GetPassword()) + "&problemNO=" +
-      bott->Getvid() + "&language=" + escapeURL(bott->Getlanguage()) +
+      bott->Getvid() + "&language=" + convertLanguage(bott->Getlanguage()) +
       "&sourceCode=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
 
@@ -125,8 +125,8 @@ Bott * AizuJudger::getStatus(Bott * bott) {
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
       result_bott->Settime_used(
-          intToString(stringToDouble(time_used) * 100 + 0.1));
-      result_bott->Setmemory_used(trim(memory_used));
+          (int)(stringToDouble(time_used) * 100 + 0.1));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/Bott.cpp
+++ b/vjudge-v2/Bott.cpp
@@ -1,6 +1,6 @@
 /* 
  * File:   Bott.cpp
-p* Author: 51isoft
+ * Author: 51isoft
  * 
  * Created on 2014年1月19日, 上午1:04
  */

--- a/vjudge-v2/Bott.cpp
+++ b/vjudge-v2/Bott.cpp
@@ -1,6 +1,6 @@
 /* 
  * File:   Bott.cpp
- * Author: 51isoft
+p* Author: 51isoft
  * 
  * Created on 2014年1月19日, 上午1:04
  */
@@ -30,7 +30,7 @@ Bott::Bott(string filename) {
     type = document["type"].GetInt();
   }
   if (document.HasMember("runid")) {
-    runid = document["runid"].GetString();
+    runid = document["runid"].GetInt();
   }
   if (document.HasMember("source")) {
     src = document["source"].GetString();
@@ -39,25 +39,25 @@ Bott::Bott(string filename) {
     ce_info = document["compileInfo"].GetString();
   }
   if (document.HasMember("language")) {
-    language = document["language"].GetString();
+    language = document["language"].GetInt();
   }
   if (document.HasMember("pid")) {
-    pid = document["pid"].GetString();
+    pid = document["pid"].GetInt();
   }
   if (document.HasMember("testcases")) {
-    number_of_testcases = document["testcases"].GetString();
+    number_of_testcases = document["testcases"].GetInt();
   }
   if (document.HasMember("timeLimit")) {
-    time_limit = document["timeLimit"].GetString();
+    time_limit = document["timeLimit"].GetInt();
   }
   if (document.HasMember("caseLimit")) {
-    case_limit = document["caseLimit"].GetString();
+    case_limit = document["caseLimit"].GetInt();
   }
   if (document.HasMember("memoryLimit")) {
-    memory_limit = document["memoryLimit"].GetString();
+    memory_limit = document["memoryLimit"].GetInt();
   }
   if (document.HasMember("spjStatus")) {
-    spj = document["spjStatus"].GetString();
+    spj = document["spjStatus"].GetInt();
   }
   if (document.HasMember("vname")) {
     vname = document["vname"].GetString();
@@ -66,23 +66,23 @@ Bott::Bott(string filename) {
     vid = document["vid"].GetString();
   }
   if (document.HasMember("memoryUsed")) {
-    memory_used = document["memoryUsed"].GetString();
+    memory_used = document["memoryUsed"].GetInt();
   }
   if (document.HasMember("timeUsed")) {
-    time_used = document["timeUsed"].GetString();
+    time_used = document["timeUsed"].GetInt();
   }
   if (document.HasMember("result")) {
     result = document["result"].GetString();
   }
   if (document.HasMember("challenge")) {
     if (document["challenge"].HasMember("id")) {
-      cha_id = document["challenge"]["id"].GetString();
+      cha_id = document["challenge"]["id"].GetInt();
     }
     if (document["challenge"].HasMember("dataType")) {
-      data_type = document["challenge"]["dataType"].GetString();
+      data_type = document["challenge"]["dataType"].GetInt();
     }
     if (document["challenge"].HasMember("dataLanguage")) {
-      data_lang = document["challenge"]["dataLanguage"].GetString();
+      data_lang = document["challenge"]["dataLanguage"].GetInt();
     }
     if (document["challenge"].HasMember("dataDetail")) {
       data_detail = document["challenge"]["dataDetail"].GetString();
@@ -101,14 +101,21 @@ void Bott::addIntValue(Document & document, const char * name, int v) {
   document.AddMember(StringRef(name), value, document.GetAllocator());
 }
 
-void Bott::addStringValue(Document & document, const char * name, string v) {
-  Value value(StringRef(v.c_str()));
+void Bott::addStringValue(Document & document, const char * name,
+                          const char * v) {
+  Value value(StringRef(v));
   document.AddMember(StringRef(name), value, document.GetAllocator());
 }
 
-void Bott::addStringValueToRef(
-    Document & document, Value & ref, const char * name, string v) {
-  Value value(StringRef(v.c_str()));
+void Bott::addIntValueToRef(
+    Document & document, Value & ref, const char * name, int v) {
+  Value value(v);
+  document.AddMember(StringRef(name), value, document.GetAllocator());
+}
+
+void Bott::addStringValueToRef(Document & document, Value & ref,
+                               const char * name, const char * v) {
+  Value value(StringRef(v));
   document.AddMember(StringRef(name), value, document.GetAllocator());
 }
 
@@ -116,12 +123,12 @@ void Bott::toFile() {
   Document document;
   document.SetObject();
   addIntValue(document, "type", type);
-  addStringValue(document, "runid", runid);
-  addStringValue(document, "memoryUsed", memory_used);
-  addStringValue(document, "timeUsed", time_used);
-  addStringValue(document, "result", result);
-  addStringValue(document, "compileInfo", ce_info);
-  addStringValue(document, "remoteRunid", remote_runid);
+  addIntValue(document, "runid", runid);
+  addIntValue(document, "memoryUsed", memory_used);
+  addIntValue(document, "timeUsed", time_used);
+  addStringValue(document, "result", result.c_str());
+  addStringValue(document, "compileInfo", ce_info.c_str());
+  addStringValue(document, "remoteRunid", remote_runid.c_str());
   
   FILE *fp = fopen(out_filename.c_str(), "w");
   StringBuffer buffer;

--- a/vjudge-v2/Bott.h
+++ b/vjudge-v2/Bott.h
@@ -21,7 +21,7 @@ public:
   /** Default destructor */
   virtual ~Bott();
 
-  int Gettype() {
+  int Gettype() const {
     return type;
   }
 
@@ -29,23 +29,23 @@ public:
     type = val;
   }
 
-  string Getrunid() {
+  int Getrunid() const {
     return runid;
   }
 
-  void Setrunid(string val) {
+  void Setrunid(int val) {
     runid = val;
   }
 
-  string Getcha_id() {
+  int Getcha_id() const {
     return cha_id;
   }
 
-  void Setcha_id(string val) {
+  void Setcha_id(int val) {
     cha_id = val;
   }
 
-  string Getsrc() {
+  string Getsrc() const {
     return src;
   }
 
@@ -53,63 +53,63 @@ public:
     src = val;
   }
 
-  string Getlanguage() {
+  int Getlanguage() const {
     return language;
   }
 
-  void Setlanguage(string val) {
+  void Setlanguage(int val) {
     language = val;
   }
 
-  string Getpid() {
+  int Getpid() const {
     return pid;
   }
 
-  void Setpid(string val) {
+  void Setpid(int val) {
     pid = val;
   }
 
-  string Getnumber_of_testcases() {
+  int Getnumber_of_testcases() const {
     return number_of_testcases;
   }
 
-  void Setnumber_of_testcases(string val) {
+  void Setnumber_of_testcases(int val) {
     number_of_testcases = val;
   }
 
-  string Gettime_limit() {
+  int Gettime_limit() const {
     return time_limit;
   }
 
-  void Settime_limit(string val) {
+  void Settime_limit(int val) {
     time_limit = val;
   }
 
-  string Getcase_limit() {
+  int Getcase_limit() const {
     return case_limit;
   }
 
-  void Setcase_limit(string val) {
+  void Setcase_limit(int val) {
     case_limit = val;
   }
 
-  string Getmemory_limit() {
+  int Getmemory_limit() const {
     return memory_limit;
   }
 
-  void Setmemory_limit(string val) {
+  void Setmemory_limit(int val) {
     memory_limit = val;
   }
 
-  string Getspj() {
+  int Getspj() const {
     return spj;
   }
 
-  void Setspj(string val) {
+  void Setspj(int val) {
     spj = val;
   }
 
-  string Getvname() {
+  string Getvname() const {
     return vname;
   }
 
@@ -117,7 +117,7 @@ public:
     vname = val;
   }
 
-  string Getvid() {
+  string Getvid() const {
     return vid;
   }
 
@@ -125,23 +125,23 @@ public:
     vid = val;
   }
 
-  string Getmemory_used() {
+  int Getmemory_used() const {
     return memory_used;
   }
 
-  void Setmemory_used(string val) {
+  void Setmemory_used(int val) {
     memory_used = val;
   }
 
-  string Gettime_used() {
+  int Gettime_used() const {
     return time_used;
   }
 
-  void Settime_used(string val) {
+  void Settime_used(int val) {
     time_used = val;
   }
 
-  string Getresult() {
+  string Getresult() const {
     return result;
   }
 
@@ -149,7 +149,7 @@ public:
     result = val;
   }
 
-  string Getce_info() {
+  string Getce_info() const {
     return ce_info;
   }
 
@@ -157,15 +157,15 @@ public:
     ce_info = val;
   }
 
-  string Getdata_type() {
+  int Getdata_type() const {
     return data_type;
   }
 
-  void Setdata_type(string val) {
+  void Setdata_type(int val) {
     data_type = val;
   }
 
-  string Getdata_detail() {
+  string Getdata_detail() const {
     return data_detail;
   }
 
@@ -173,15 +173,15 @@ public:
     data_detail = val;
   }
 
-  string Getdata_lang() {
+  int Getdata_lang() const {
     return data_lang;
   }
 
-  void Setdata_lang(string val) {
+  void Setdata_lang(int val) {
     data_lang = val;
   }
 
-  string Getcha_result() {
+  string Getcha_result() const {
     return cha_result;
   }
 
@@ -189,7 +189,7 @@ public:
     cha_result = val;
   }
 
-  string Getcha_detail() {
+  string Getcha_detail() const {
     return cha_detail;
   }
 
@@ -197,7 +197,7 @@ public:
     cha_detail = val;
   }
 
-  string Getout_filename() {
+  string Getout_filename() const {
     return out_filename;
   }
 
@@ -236,32 +236,33 @@ public:
 protected:
 private:
   int type;
-  string runid;
-  string cha_id;
+  int runid;
+  int cha_id;
   string src;
-  string language;
-  string pid;
-  string number_of_testcases;
-  string time_limit;
-  string case_limit;
-  string memory_limit;
-  string spj;
+  int language;
+  int pid;
+  int number_of_testcases;
+  int time_limit;
+  int case_limit;
+  int memory_limit;
+  int spj;
   string vname;
   string vid;
-  string memory_used;
-  string time_used;
+  int memory_used;
+  int time_used;
   string result;
   string ce_info;
-  string data_type;
-  string data_lang;
+  int data_type;
+  int data_lang;
   string data_detail;
   string cha_result;
   string cha_detail;
   string remote_runid;
 
   void addIntValue(Document &, const char *, int);
-  void addStringValue(Document &, const char *, string);
-  void addStringValueToRef(Document &, Value &, const char *, string);
+  void addStringValue(Document &, const char *, const char *);
+  void addIntValueToRef(Document &, Value &, const char *, int);
+  void addStringValueToRef(Document &, Value &, const char *, const char *);
   string out_filename;
 
 };

--- a/vjudge-v2/CCJudger.cpp
+++ b/vjudge-v2/CCJudger.cpp
@@ -12,16 +12,16 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 CCJudger::CCJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "41";
-  language_table["2"] = "11";
-  language_table["3"] = "10";
-  language_table["4"] = "22";
-  language_table["5"] = "4";
-  language_table["6"] = "27";
-  language_table["7"] = "5";
-  language_table["8"] = "3";
-  language_table["9"] = "17";
-  language_table["10"] = "7";
+  language_table[CPPLANG] = "41";
+  language_table[CLANG] = "11";
+  language_table[JAVALANG] = "10";
+  language_table[FPASLANG] = "22";
+  language_table[PYLANG] = "4";
+  language_table[CSLANG] = "27";
+  language_table[FORTLANG] = "5";
+  language_table[PERLLANG] = "3";
+  language_table[RUBYLANG] = "17";
+  language_table[ADALANG] = "7";
 }
 
 CCJudger::~CCJudger() {
@@ -138,7 +138,8 @@ int CCJudger::submit(Bott * bott) {
   }
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "submission_language",
-               CURLFORM_COPYCONTENTS, bott->Getlanguage().c_str(),
+               CURLFORM_COPYCONTENTS,
+                   convertLanguage(bott->Getlanguage()).c_str(),
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "body",
@@ -224,7 +225,7 @@ Bott * CCJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(result);
-      result_bott->Settime_used(intToString(time_ms));
+      result_bott->Settime_used(time_ms);
 
       if (result != "Compile Error") {
         // CodeChef will update Memory usage later in submission table
@@ -250,7 +251,7 @@ Bott * CCJudger::getStatus(Bott * bott) {
         }
         memory_kb = stringToDouble(memory_used) * 1024 + 0.001;
       }
-      result_bott->Setmemory_used(intToString(memory_kb));
+      result_bott->Setmemory_used(memory_kb);
       result_bott->Setremote_runid(bott->Getremote_runid());
       break;
     }

--- a/vjudge-v2/CFJudger.cpp
+++ b/vjudge-v2/CFJudger.cpp
@@ -12,14 +12,14 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 CFJudger::CFJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "1";
-  language_table["2"]  = "10";
-  language_table["3"]  = "23";
-  language_table["4"]  = "4";
-  language_table["5"]  = "7";
-  language_table["6"]  = "9";
-  language_table["9"]  = "8";
-  language_table["12"] = "2";
+  language_table[CPPLANG]  = "1";
+  language_table[CLANG]  = "10";
+  language_table[JAVALANG]  = "23";
+  language_table[FPASLANG]  = "4";
+  language_table[PYLANG]  = "7";
+  language_table[CSLANG]  = "9";
+  language_table[RUBYLANG]  = "8";
+  language_table[VCLANG] = "2";
 }
 
 CFJudger::~CFJudger() {
@@ -151,7 +151,8 @@ int CFJudger::submit(Bott * bott) {
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "programTypeId",
-               CURLFORM_COPYCONTENTS, bott->Getlanguage().c_str(),
+               CURLFORM_COPYCONTENTS,
+                   convertLanguage(bott->Getlanguage()).c_str(),
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "source",
@@ -251,8 +252,8 @@ Bott * CFJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/FZUJudger.cpp
+++ b/vjudge-v2/FZUJudger.cpp
@@ -8,12 +8,12 @@
 #include "FZUJudger.h"
 
 FZUJudger::FZUJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "0";
-  language_table["2"]  = "1";
-  language_table["3"]  = "2";
-  language_table["4"]  = "3";
-  language_table["12"] = "4";
-  language_table["13"] = "5";
+  language_table[CPPLANG]  = "0";
+  language_table[CLANG]  = "1";
+  language_table[JAVALANG]  = "2";
+  language_table[FPASLANG]  = "3";
+  language_table[VCLANG] = "4";
+  language_table[VCPPLANG] = "5";
 }
 
 FZUJudger::~FZUJudger() {
@@ -51,7 +51,7 @@ int FZUJudger::submit(Bott * bott) {
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL, "http://acm.fzu.edu.cn/submit.php?act=5");
   string post = (string) "usr=" + info->GetUsername() + "&lang=" +
-      bott->Getlanguage() + "&pid=" + bott->Getvid() + "&code=" +
+      convertLanguage(bott->Getlanguage()) + "&pid=" + bott->Getvid() + "&code=" +
       escapeURL(bott->Getsrc()) + "&submit=Submit";
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
@@ -118,8 +118,8 @@ Bott * FZUJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/HDUJudger.cpp
+++ b/vjudge-v2/HDUJudger.cpp
@@ -8,12 +8,12 @@
 #include "HDUJudger.h"
 
 HDUJudger::HDUJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "0";
-  language_table["2"]  = "1";
-  language_table["3"]  = "5";
-  language_table["4"]  = "4";
-  language_table["12"] = "2";
-  language_table["13"] = "3";
+  language_table[CPPLANG]  = "0";
+  language_table[CLANG]  = "1";
+  language_table[JAVALANG]  = "5";
+  language_table[FPASLANG]  = "4";
+  language_table[VCLANG] = "2";
+  language_table[VCPPLANG] = "3";
 }
 
 HDUJudger::~HDUJudger() {
@@ -62,8 +62,9 @@ int HDUJudger::submit(Bott * bott) {
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL,
                    "http://acm.hdu.edu.cn/submit.php?action=submit");
-  string post = (string) "check=0&problemid=" + bott->Getvid() + "&language=" +
-      bott->Getlanguage() + "&usercode=" + escapeURL(converted_code);
+  string post = (string) "check=0&problemid=" + bott->Getvid() +
+      "&language=" + convertLanguage(bott->Getlanguage()) +
+      "&usercode=" + escapeURL(converted_code);
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
 
@@ -140,8 +141,8 @@ Bott * HDUJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/HRBUSTJudger.cpp
+++ b/vjudge-v2/HRBUSTJudger.cpp
@@ -8,9 +8,9 @@
 #include "HRBUSTJudger.h"
 
 HRBUSTJudger::HRBUSTJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "2";
-  language_table["2"]  = "1";
-  language_table["3"]  = "3";
+  language_table[CPPLANG]  = "2";
+  language_table[CLANG]  = "1";
+  language_table[JAVALANG]  = "3";
 }
 
 HRBUSTJudger::~HRBUSTJudger() {
@@ -51,9 +51,9 @@ int HRBUSTJudger::submit(Bott * bott) {
   curl_easy_setopt(curl,
                    CURLOPT_URL,
                    "http://acm.hrbust.edu.cn/index.php?m=ProblemSet&a=postCode");
-  string post = (string) "jumpUrl=&language=" + bott->Getlanguage() +
-      "&problem_id=" + bott->Getvid() + "&source_code=" +
-      escapeURL(bott->Getsrc());
+  string post = (string) "jumpUrl=&language=" +
+      convertLanguage(bott->Getlanguage()) + "&problem_id=" + bott->Getvid() +
+      "&source_code=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
 
@@ -85,7 +85,7 @@ Bott * HRBUSTJudger::getStatus(Bott * bott) {
         ((string) "http://acm.hrbust.edu.cn/index.php?m=Status&a="
             "showStatus&problem_id=" + escapeURL(bott->Getvid()) +
             "&user_name=" + escapeURL(info->GetUsername()) + "&language=" +
-            escapeURL(bott->Getlanguage())).c_str());
+            convertLanguage(bott->Getlanguage())).c_str());
     performCurl();
 
     string html = loadAllFromFile(tmpfilename);
@@ -117,8 +117,8 @@ Bott * HRBUSTJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(result);
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/HUSTJudger.cpp
+++ b/vjudge-v2/HUSTJudger.cpp
@@ -8,10 +8,10 @@
 #include "HUSTJudger.h"
 
 HUSTJudger::HUSTJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "1";
-  language_table["2"]  = "0";
-  language_table["3"]  = "3";
-  language_table["4"]  = "2";
+  language_table[CPPLANG]  = "1";
+  language_table[CLANG]  = "0";
+  language_table[JAVALANG]  = "3";
+  language_table[FPASLANG]  = "2";
 }
 
 HUSTJudger::~HUSTJudger() {
@@ -48,7 +48,7 @@ int HUSTJudger::submit(Bott * bott) {
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL, "http://acm.hust.edu.cn/problem/submit");
   string post = (string) "pid=" + bott->Getvid() + "&language=" +
-      bott->Getlanguage() + "&source=" + escapeURL(bott->Getsrc());
+      convertLanguage(bott->Getlanguage()) + "&source=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
 
@@ -78,7 +78,7 @@ Bott * HUSTJudger::getStatus(Bott * bott) {
         curl, CURLOPT_URL,
         ((string) "http://acm.hust.edu.cn/status?pid=" + bott->Getvid() +
             "&uid=" + info->GetUsername() + "&language" +
-            bott->Getlanguage()).c_str());
+            convertLanguage(bott->Getlanguage())).c_str());
     performCurl();
 
     string html = loadAllFromFile(tmpfilename);
@@ -111,8 +111,8 @@ Bott * HUSTJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/HUSTJudger.cpp
+++ b/vjudge-v2/HUSTJudger.cpp
@@ -47,8 +47,9 @@ void HUSTJudger::login() {
 int HUSTJudger::submit(Bott * bott) {
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL, "http://acm.hust.edu.cn/problem/submit");
-  string post = (string) "pid=" + bott->Getvid() + "&language=" +
-      convertLanguage(bott->Getlanguage()) + "&source=" + escapeURL(bott->Getsrc());
+  string post = (string) "pid=" + bott->Getvid() +
+      "&language=" + convertLanguage(bott->Getlanguage()) +
+      "&source=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
 

--- a/vjudge-v2/LOJJudger.cpp
+++ b/vjudge-v2/LOJJudger.cpp
@@ -12,11 +12,11 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 LOJJudger::LOJJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "C++";
-  language_table["2"] = "C";
-  language_table["3"] = "JAVA";
-  language_table["4"] = "PASCAL";
-  language_table["5"] = "PYTHON";
+  language_table[CPPLANG] = "C++";
+  language_table[CLANG] = "C";
+  language_table[JAVALANG] = "JAVA";
+  language_table[FPASLANG] = "PASCAL";
+  language_table[PYLANG] = "PYTHON";
 }
 
 LOJJudger::~LOJJudger() {
@@ -61,7 +61,8 @@ int LOJJudger::submit(Bott * bott) {
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "language",
-               CURLFORM_COPYCONTENTS, bott->Getlanguage().c_str(),
+               CURLFORM_COPYCONTENTS,
+                   convertLanguage(bott->Getlanguage()).c_str(),
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "code",
@@ -141,8 +142,8 @@ Bott * LOJJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(result);
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/NBUTJudger.cpp
+++ b/vjudge-v2/NBUTJudger.cpp
@@ -54,8 +54,9 @@ int NBUTJudger::submit(Bott * bott) {
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL,
                    "https://ac.2333.moe/Problem/submitok.xhtml");
-  string post = (string) "id=" + bott->Getvid() + "&language=" +
-      convertLanguage(bott->Getlanguage()) + "&code=" + escapeURL(bott->Getsrc());
+  string post = (string) "id=" + bott->Getvid() +
+      "&language=" + convertLanguage(bott->Getlanguage()) +
+      "&code=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
 

--- a/vjudge-v2/NBUTJudger.cpp
+++ b/vjudge-v2/NBUTJudger.cpp
@@ -12,9 +12,9 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 NBUTJudger::NBUTJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "2";
-  language_table["2"] = "1";
-  language_table["4"] = "4";
+  language_table[CPPLANG] = "2";
+  language_table[CLANG] = "1";
+  language_table[FPASLANG] = "4";
 }
 
 NBUTJudger::~NBUTJudger() {
@@ -55,7 +55,7 @@ int NBUTJudger::submit(Bott * bott) {
   curl_easy_setopt(curl, CURLOPT_URL,
                    "https://ac.2333.moe/Problem/submitok.xhtml");
   string post = (string) "id=" + bott->Getvid() + "&language=" +
-      bott->Getlanguage() + "&code=" + escapeURL(bott->Getsrc());
+      convertLanguage(bott->Getlanguage()) + "&code=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
 
@@ -88,7 +88,7 @@ Bott * NBUTJudger::getStatus(Bott * bott) {
         curl, CURLOPT_URL,
         ((string)"https://ac.2333.moe/Problem/status.xhtml?username=" +
             escapeURL(info->GetUsername()) + "&language=" +
-            escapeURL(bott->Getlanguage()) + "&problemid=" +
+            convertLanguage(bott->Getlanguage()) + "&problemid=" +
             escapeURL(bott->Getvid())).c_str());
     performCurl();
 
@@ -120,8 +120,8 @@ Bott * NBUTJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/NJUPTJudger.cpp
+++ b/vjudge-v2/NJUPTJudger.cpp
@@ -8,10 +8,10 @@
 #include "NJUPTJudger.h"
 
 NJUPTJudger::NJUPTJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "G++";
-  language_table["2"]  = "GCC";
-  language_table["3"]  = "Java";
-  language_table["4"]  = "Pascal";
+  language_table[CPPLANG]  = "G++";
+  language_table[CLANG]  = "GCC";
+  language_table[JAVALANG]  = "Java";
+  language_table[FPASLANG]  = "Pascal";
 }
 
 NJUPTJudger::~NJUPTJudger() {
@@ -50,7 +50,7 @@ int NJUPTJudger::submit(Bott * bott) {
   curl_easy_setopt(curl, CURLOPT_URL,
                    "http://acm.njupt.edu.cn/acmhome/submitcode.do");
   string post = (string) "problemId=" + bott->Getvid() + "&language=" +
-      escapeURL(bott->Getlanguage()) + "&code=" + escapeURL(bott->Getsrc());
+      convertLanguage(bott->Getlanguage()) + "&code=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
 
   try {
@@ -85,7 +85,7 @@ Bott * NJUPTJudger::getStatus(Bott * bott) {
         curl, CURLOPT_URL,
         ((string) "http://acm.njupt.edu.cn/acmhome/showstatus.do").c_str());
     string post = (string) "problemId=" + bott->Getvid() + "&languageS=" +
-        escapeURL(bott->Getlanguage()) + "&userName=" +
+        convertLanguage(bott->Getlanguage()) + "&userName=" +
         escapeURL(info->GetUsername()) + "&resultS=All";
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
     performCurl();
@@ -125,8 +125,8 @@ Bott * NJUPTJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/NJUPTJudger.cpp
+++ b/vjudge-v2/NJUPTJudger.cpp
@@ -49,8 +49,9 @@ int NJUPTJudger::submit(Bott * bott) {
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL,
                    "http://acm.njupt.edu.cn/acmhome/submitcode.do");
-  string post = (string) "problemId=" + bott->Getvid() + "&language=" +
-      convertLanguage(bott->Getlanguage()) + "&code=" + escapeURL(bott->Getsrc());
+  string post = (string) "problemId=" + bott->Getvid() +
+      "&language=" + convertLanguage(bott->Getlanguage()) +
+      "&code=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
 
   try {

--- a/vjudge-v2/OpenJudgeJudger.cpp
+++ b/vjudge-v2/OpenJudgeJudger.cpp
@@ -12,10 +12,10 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 OpenJudgeJudger::OpenJudgeJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "G++";
-  language_table["2"] = "GCC";
-  language_table["3"] = "Java";
-  language_table["4"] = "Pascal";
+  language_table[CPPLANG] = "G++";
+  language_table[CLANG] = "GCC";
+  language_table[JAVALANG] = "Java";
+  language_table[FPASLANG] = "Pascal";
 }
 
 OpenJudgeJudger::~OpenJudgeJudger() {
@@ -55,8 +55,9 @@ int OpenJudgeJudger::submit(Bott * bott) {
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL,
                    "http://poj.openjudge.cn/api/solution/submit/");
-  string post = "contestId=2&problemNumber=" + bott->Getvid() + "&language="
-      + escapeURL(bott->Getlanguage()) + "&source=" + escapeURL(bott->Getsrc());
+  string post = "contestId=2&problemNumber=" + bott->Getvid() +
+      "&language=" + convertLanguage(bott->Getlanguage()) +
+      "&source=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
 
@@ -130,8 +131,8 @@ Bott * OpenJudgeJudger::getStatus(Bott * bott) {
       result_bott->Setremote_runid(bott->Getremote_runid());
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(result);
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       break;
     }
   }

--- a/vjudge-v2/PKUJudger.cpp
+++ b/vjudge-v2/PKUJudger.cpp
@@ -12,12 +12,12 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 PKUJudger::PKUJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "0";
-  language_table["2"]  = "1";
-  language_table["3"]  = "2";
-  language_table["4"]  = "3";
-  language_table["12"] = "4";
-  language_table["13"] = "5";
+  language_table[CPPLANG]  = "0";
+  language_table[CLANG]  = "1";
+  language_table[JAVALANG]  = "2";
+  language_table[FPASLANG]  = "3";
+  language_table[VCLANG] = "4";
+  language_table[VCPPLANG] = "5";
 }
 
 PKUJudger::~PKUJudger() {
@@ -52,7 +52,7 @@ void PKUJudger::login() {
  */
 int PKUJudger::submit(Bott * bott) {
   string post = (string) "problem_id=" + bott->Getvid() + "&language=" +
-      bott->Getlanguage() + "&source=" + escapeURL(bott->Getsrc());
+      convertLanguage(bott->Getlanguage()) + "&source=" + escapeURL(bott->Getsrc());
   try {
     prepareCurl();
     curl_easy_setopt(curl, CURLOPT_URL, "http://poj.org/submit");
@@ -95,7 +95,7 @@ Bott * PKUJudger::getStatus(Bott * bott) {
         curl, CURLOPT_URL,
         ((string) "http://poj.org/status?problem_id=" + bott->Getvid() +
             "&user_id=" + info->GetUsername() + "&language=" +
-            bott->Getlanguage()).c_str());
+            convertLanguage(bott->Getlanguage())).c_str());
     curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
     curl_easy_setopt(curl, CURLOPT_COOKIEJAR, "");
     performCurl();
@@ -132,8 +132,8 @@ Bott * PKUJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/PKUJudger.cpp
+++ b/vjudge-v2/PKUJudger.cpp
@@ -51,8 +51,9 @@ void PKUJudger::login() {
  * @return Submit status
  */
 int PKUJudger::submit(Bott * bott) {
-  string post = (string) "problem_id=" + bott->Getvid() + "&language=" +
-      convertLanguage(bott->Getlanguage()) + "&source=" + escapeURL(bott->Getsrc());
+  string post = (string) "problem_id=" + bott->Getvid() +
+      "&language=" + convertLanguage(bott->Getlanguage()) +
+      "&source=" + escapeURL(bott->Getsrc());
   try {
     prepareCurl();
     curl_easy_setopt(curl, CURLOPT_URL, "http://poj.org/submit");

--- a/vjudge-v2/SCUJudger.cpp
+++ b/vjudge-v2/SCUJudger.cpp
@@ -58,8 +58,9 @@ int SCUJudger::submit(Bott * bott) {
   curl_easy_setopt(curl, CURLOPT_URL,
                    "http://cstest.scu.edu.cn/soj/submit.action");
   string post = (string) "problemId=" + bott->Getvid() +
-      "&submit=Submit&validation=" + code + "&language=" +
-      convertLanguage(bott->Getlanguage()) + "&source=" + escapeURL(bott->Getsrc());
+      "&submit=Submit&validation=" + code +
+      "&language=" + convertLanguage(bott->Getlanguage()) +
+      "&source=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
 

--- a/vjudge-v2/SCUJudger.cpp
+++ b/vjudge-v2/SCUJudger.cpp
@@ -13,10 +13,10 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 SCUJudger::SCUJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "C++ (G++-3)";
-  language_table["2"] = "C (GCC-3)";
-  language_table["3"] = "JAVA";
-  language_table["4"] = "PASCAL (GPC)";
+  language_table[CPPLANG] = "C++ (G++-3)";
+  language_table[CLANG] = "C (GCC-3)";
+  language_table[JAVALANG] = "JAVA";
+  language_table[FPASLANG] = "PASCAL (GPC)";
 }
 
 SCUJudger::~SCUJudger() {
@@ -59,7 +59,7 @@ int SCUJudger::submit(Bott * bott) {
                    "http://cstest.scu.edu.cn/soj/submit.action");
   string post = (string) "problemId=" + bott->Getvid() +
       "&submit=Submit&validation=" + code + "&language=" +
-      escapeURL(bott->Getlanguage()) + "&source=" + escapeURL(bott->Getsrc());
+      convertLanguage(bott->Getlanguage()) + "&source=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
 
@@ -125,8 +125,8 @@ Bott * SCUJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(result);
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/SGUJudger.cpp
+++ b/vjudge-v2/SGUJudger.cpp
@@ -12,13 +12,13 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 SGUJudger::SGUJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "GNU CPP (MinGW, GCC 4)";
-  language_table["2"] = "GNU C (MinGW, GCC 4)";
-  language_table["3"] = "JAVA 7";
-  language_table["4"] = "Delphi 7.0";
-  language_table["6"] = "C#";
-  language_table["12"] = "Visual Studio C++ 2010";
-  language_table["13"] = "Visual Studio C 2010";
+  language_table[CPPLANG] = "GNU CPP (MinGW, GCC 4)";
+  language_table[CLANG] = "GNU C (MinGW, GCC 4)";
+  language_table[JAVALANG] = "JAVA 7";
+  language_table[FPASLANG] = "Delphi 7.0";
+  language_table[CSLANG] = "C#";
+  language_table[VCLANG] = "Visual Studio C++ 2010";
+  language_table[VCPPLANG] = "Visual Studio C 2010";
 }
 
 SGUJudger::~SGUJudger() {
@@ -60,7 +60,7 @@ int SGUJudger::submit(Bott * bott) {
                    "http://acm.sgu.ru/sendfile.php?contest=0");
   string post = (string) "id=" + escapeURL(info->GetUsername()) + "&pass=" +
       escapeURL(info->GetPassword()) + "&problem=" + bott->Getvid() +
-      "&elang=" + escapeURL(bott->Getlanguage()) + "&source=" +
+      "&elang=" + convertLanguage(bott->Getlanguage()) + "&source=" +
       escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
@@ -124,8 +124,8 @@ Bott * SGUJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/SPOJJudger.cpp
+++ b/vjudge-v2/SPOJJudger.cpp
@@ -12,16 +12,16 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 SPOJJudger::SPOJJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "41";
-  language_table["2"] = "11";
-  language_table["3"] = "10";
-  language_table["4"] = "22";
-  language_table["5"] = "4";
-  language_table["6"] = "27";
-  language_table["7"] = "5";
-  language_table["8"] = "3";
-  language_table["9"] = "17";
-  language_table["10"] = "7";
+  language_table[CPPLANG] = "41";
+  language_table[CLANG] = "11";
+  language_table[JAVALANG] = "10";
+  language_table[FPASLANG] = "22";
+  language_table[PYLANG] = "4";
+  language_table[CSLANG] = "27";
+  language_table[FORTLANG] = "5";
+  language_table[PERLLANG] = "3";
+  language_table[RUBYLANG] = "17";
+  language_table[ADALANG] = "7";
 }
 
 SPOJJudger::~SPOJJudger() {
@@ -72,7 +72,8 @@ int SPOJJudger::submit(Bott * bott) {
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "lang",
-               CURLFORM_COPYCONTENTS, bott->Getlanguage().c_str(),
+               CURLFORM_COPYCONTENTS,
+                   convertLanguage(bott->Getlanguage()).c_str(),
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "file",
@@ -159,8 +160,8 @@ Bott * SPOJJudger::getStatus(Bott * bott) {
       result_bott->Setremote_runid(runid);
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(result);
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       break;
     }
   }

--- a/vjudge-v2/SYSUJudger.cpp
+++ b/vjudge-v2/SYSUJudger.cpp
@@ -12,9 +12,9 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 SYSUJudger::SYSUJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "2";
-  language_table["2"] = "1";
-  language_table["4"] = "3";
+  language_table[CPPLANG] = "2";
+  language_table[CLANG] = "1";
+  language_table[FPASLANG] = "3";
 }
 
 SYSUJudger::~SYSUJudger() {
@@ -53,7 +53,8 @@ int SYSUJudger::submit(Bott * bott) {
 
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL, "http://soj.sysu.edu.cn/action.php?act=Submit");
-  string post = (string) "cid=0&language=" + bott->Getlanguage() + "&pid=" +
+  string post = (string)
+      "cid=0&language=" + convertLanguage(bott->Getlanguage()) + "&pid=" +
       bott->Getvid() + "&source=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
@@ -121,8 +122,8 @@ Bott * SYSUJudger::getStatus(Bott * bott) {
       result_bott->Setremote_runid(bott->Getremote_runid());
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(result);
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       break;
     }
   }

--- a/vjudge-v2/UESTCJudger.cpp
+++ b/vjudge-v2/UESTCJudger.cpp
@@ -5,9 +5,9 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 UESTCJudger::UESTCJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "2";
-  language_table["2"]  = "1";
-  language_table["3"]  = "3";
+  language_table[CPPLANG]  = "2";
+  language_table[CLANG]  = "1";
+  language_table[JAVALANG]  = "3";
 }
 
 UESTCJudger::~UESTCJudger() {
@@ -54,7 +54,7 @@ void UESTCJudger::login() {
 int UESTCJudger::submit(Bott * bott) {
   string post = (string) "{\"codeContent\":\"" + escapeString(bott->Getsrc()) +
       "\",\"problemId\":" + bott->Getvid() + ",\"contestId\":null," +
-      "\"languageId\":" + bott->Getlanguage() + "}";
+      "\"languageId\":" + convertLanguage(bott->Getlanguage()) + "}";
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL,
       "http://acm.uestc.edu.cn/status/submit");
@@ -125,8 +125,8 @@ Bott * UESTCJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/UVAJudger.cpp
+++ b/vjudge-v2/UVAJudger.cpp
@@ -12,10 +12,10 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 UVAJudger::UVAJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "3";
-  language_table["2"]  = "1";
-  language_table["3"]  = "2";
-  language_table["4"]  = "4";
+  language_table[CPPLANG]  = "3";
+  language_table[CLANG]  = "1";
+  language_table[JAVALANG]  = "2";
+  language_table[FPASLANG]  = "4";
 }
 
 UVAJudger::~UVAJudger() {
@@ -95,7 +95,8 @@ int UVAJudger::submit(Bott * bott) {
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "language",
-               CURLFORM_COPYCONTENTS, bott->Getlanguage().c_str(),
+               CURLFORM_COPYCONTENTS,
+                   convertLanguage(bott->Getlanguage()).c_str(),
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "code",
@@ -178,8 +179,8 @@ Bott * UVAJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(intToString(time_ms));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(time_ms);
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/UVALiveJudger.cpp
+++ b/vjudge-v2/UVALiveJudger.cpp
@@ -12,10 +12,10 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 UVALiveJudger::UVALiveJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"]  = "3";
-  language_table["2"]  = "1";
-  language_table["3"]  = "2";
-  language_table["4"]  = "4";
+  language_table[CPPLANG]  = "3";
+  language_table[CLANG]  = "1";
+  language_table[JAVALANG]  = "2";
+  language_table[FPASLANG]  = "4";
 }
 
 UVALiveJudger::~UVALiveJudger() {
@@ -98,7 +98,8 @@ int UVALiveJudger::submit(Bott * bott) {
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "language",
-               CURLFORM_COPYCONTENTS, bott->Getlanguage().c_str(),
+               CURLFORM_COPYCONTENTS,
+                   convertLanguage(bott->Getlanguage()).c_str(),
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "code",
@@ -181,8 +182,8 @@ Bott * UVALiveJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(convertResult(result));
-      result_bott->Settime_used(intToString(time_ms));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(time_ms);
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/UralJudger.cpp
+++ b/vjudge-v2/UralJudger.cpp
@@ -12,11 +12,11 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 UralJudger::UralJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "26";
-  language_table["2"] = "25";
-  language_table["3"] = "32";
-  language_table["4"] = "31";
-  language_table["6"] = "11";
+  language_table[CPPLANG] = "26";
+  language_table[CLANG] = "25";
+  language_table[JAVALANG] = "32";
+  language_table[FPASLANG] = "31";
+  language_table[CSLANG] = "11";
 
   if (!RE2::PartialMatch(info->GetUsername(), "([0-9]*)", &author_id)) {
       throw Exception("Cannot retrieve author id from username");
@@ -59,7 +59,8 @@ int UralJudger::submit(Bott * bott) {
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "Language",
-               CURLFORM_COPYCONTENTS, bott->Getlanguage().c_str(),
+               CURLFORM_COPYCONTENTS,
+                   convertLanguage(bott->Getlanguage()).c_str(),
                CURLFORM_END);
   curl_formadd(&formpost, &lastptr,
                CURLFORM_COPYNAME, "ProblemNum",
@@ -148,8 +149,8 @@ Bott * UralJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(result);
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/VirtualJudger.h
+++ b/vjudge-v2/VirtualJudger.h
@@ -64,12 +64,13 @@ protected:
 
   void prepareCurl();
   void performCurl();
+  string convertLanguage(int);
   SocketHandler * socket;
   JudgerInfo * info;
   string tmpfilename;
   string cookiefilename;
   // language convertion table, convert local language to remote ones
-  map <string, string> language_table;
+  map <int, string> language_table;
   bool logged_in;
 
   CURL * curl;

--- a/vjudge-v2/WHUJudger.cpp
+++ b/vjudge-v2/WHUJudger.cpp
@@ -13,10 +13,10 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 WHUJudger::WHUJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "2";
-  language_table["2"] = "1";
-  language_table["3"] = "3";
-  language_table["4"] = "4";
+  language_table[CPPLANG] = "2";
+  language_table[CLANG] = "1";
+  language_table[JAVALANG] = "3";
+  language_table[FPASLANG] = "4";
 }
 
 WHUJudger::~WHUJudger() {
@@ -80,8 +80,8 @@ int WHUJudger::submit(Bott * bott) {
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL,
                    "http://acm.whu.edu.cn/land/submit/do_submit");
-  string post = "lang=" + bott->Getlanguage() + "&problem_id=" +
-      bott->Getvid() + "&source=" + escapeURL(bott->Getsrc()) +
+  string post = "lang=" + convertLanguage(bott->Getlanguage()) +
+      "&problem_id=" + bott->Getvid() + "&source=" + escapeURL(bott->Getsrc()) +
       "&submit=Submit";
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
@@ -117,7 +117,7 @@ Bott * WHUJudger::getStatus(Bott * bott) {
         curl, CURLOPT_URL,
         ((string) "http://acm.whu.edu.cn/land/status?username=" +
             info->GetUsername() + "&problem_id=" + bott->Getvid() +
-            "&language=" + bott->Getlanguage()).c_str());
+            "&language=" + convertLanguage(bott->Getlanguage())).c_str());
     performCurl();
 
     string html = loadAllFromFile(tmpfilename);
@@ -150,8 +150,8 @@ Bott * WHUJudger::getStatus(Bott * bott) {
       result_bott = new Bott;
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(result);
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       result_bott->Setremote_runid(trim(runid));
       break;
     }

--- a/vjudge-v2/ZJUJudger.cpp
+++ b/vjudge-v2/ZJUJudger.cpp
@@ -12,12 +12,12 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 ZJUJudger::ZJUJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table["1"] = "2";
-  language_table["2"] = "1";
-  language_table["3"] = "4";
-  language_table["4"] = "3";
-  language_table["5"] = "5";
-  language_table["8"] = "6";
+  language_table[CPPLANG] = "2";
+  language_table[CLANG] = "1";
+  language_table[JAVALANG] = "4";
+  language_table[FPASLANG] = "3";
+  language_table[PYLANG] = "5";
+  language_table[PERLLANG] = "6";
 }
 
 ZJUJudger::~ZJUJudger() {
@@ -57,8 +57,9 @@ int ZJUJudger::submit(Bott * bott) {
   prepareCurl();
   curl_easy_setopt(curl, CURLOPT_URL,
                    "http://acm.zju.edu.cn/onlinejudge/submit.do");
-  string post = (string) "problemCode=" + bott->Getvid() + "&languageId=" +
-      bott->Getlanguage() + "&source=" + escapeURL(bott->Getsrc());
+  string post = (string) "problemCode=" + bott->Getvid() +
+      "&languageId=" + convertLanguage(bott->Getlanguage()) +
+      "&source=" + escapeURL(bott->Getsrc());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.c_str());
   performCurl();
 
@@ -131,8 +132,8 @@ Bott * ZJUJudger::getStatus(Bott * bott) {
       result_bott->Setremote_runid(bott->Getremote_runid());
       result_bott->Settype(RESULT_REPORT);
       result_bott->Setresult(result);
-      result_bott->Settime_used(trim(time_used));
-      result_bott->Setmemory_used(trim(memory_used));
+      result_bott->Settime_used(stringToInt(time_used));
+      result_bott->Setmemory_used(stringToInt(memory_used));
       if (result == "Compile Error") {
         // hack for ZJU, don't know why its submission id is inconsistent with
         // judge protocol

--- a/vjudge-v2/vjudge.h
+++ b/vjudge-v2/vjudge.h
@@ -59,5 +59,24 @@ using namespace std;
 #define RESULT_REPORT 1003
 #define CHALLENGE_REPORT 1004
 
+// language
+#define MIN_LANG_NUM 1
+#define CPPLANG 1
+#define CLANG 2
+#define JAVALANG 3
+#define FPASLANG 4
+#define PYLANG 5
+#define CSLANG 6
+#define FORTLANG 7
+#define PERLLANG 8
+#define RUBYLANG 9
+#define ADALANG 10
+#define SMLLANG 11
+#define VCLANG 12
+#define VCPPLANG 13
+#define CLANGLANG 14
+#define CLANGPPLANG 15
+#define MAX_LANG_NUM 15
+
 #endif /* VJUDGE_H */
 


### PR DESCRIPTION
remote_runid is intented to be left as string, since it's entirely decided by remote judges.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bnuacm/bnuoj-vjudge/17)

<!-- Reviewable:end -->
