### PR TITLE
CF: Update language to Java 1.8, G++11 and GCC C11

### DIFF
--- a/vjudge-v2/src/CFJudger.cpp
+++ b/vjudge-v2/src/CFJudger.cpp
@@ -12,9 +12,9 @@
  * @param _info Should be a pointer of a JudgerInfo
  */
 CFJudger::CFJudger(JudgerInfo * _info) : VirtualJudger(_info) {
-  language_table[CPPLANG]  = "1";
-  language_table[CLANG]  = "10";
-  language_table[JAVALANG]  = "23";
+  language_table[CPPLANG]  = "42";
+  language_table[CLANG]  = "43";
+  language_table[JAVALANG]  = "36";
   language_table[FPASLANG]  = "4";
   language_table[PYLANG]  = "7";
   language_table[CSLANG]  = "9";


### PR DESCRIPTION
Codeforces no more supports Java 1.7 and users have an urge to enjoy C++11.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bnuacm/bnuoj-vjudge/26)

<!-- Reviewable:end -->
